### PR TITLE
Update master_configuration_set

### DIFF
--- a/master_configuration_set
+++ b/master_configuration_set
@@ -85,22 +85,22 @@ q1.vectorbase.org              vect-inc    apicommDevS         acctdbS          
 q1.veupathdb.org               eupa-inc    apicommDevS         acctdbS           webwww            webwww          webwww     apiSite            master
 q1.orthomcl.org                rm51069     apicommDevS         acctdbS           webwww            webwww          webwww     orthoSite          master
 
-q2.amoebadb.org                ameb-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.cryptodb.org                cryp-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.fungidb.org                 fung-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.giardiadb.org               giar-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.hostdb.org                  host-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.microsporidiadb.org         micr-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.piroplasmadb.org            piro-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.plasmodb.org                plas-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.toxodb.org                  toxo-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.trichdb.org                 tvag-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.tritrypdb.org               tryp-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
+q2.amoebadb.org                ameb068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.cryptodb.org                cryp068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.fungidb.org                 fung068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.giardiadb.org               giar068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.hostdb.org                  host068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.microsporidiadb.org         micr068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.piroplasmadb.org            piro068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.plasmodb.org                plas068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.toxodb.org                  toxo068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.trichdb.org                 tvag068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.tritrypdb.org               tryp068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
 q2.microbiomedb.org            eda-inc     cecommDevN          acctdbN           webwww            webwww          webwww     microbiomeSite     master
 q2.clinepidb.org               eda-inc     cecommdevN          acctdbN           webwww            webwww          webwww     clinEpiSite        master
 q2.restricted.clinepidb.org    eda-inc     cecommdevN          acctdbN           webwww            webwww          webwww     clinEpiSite        master
-q2.vectorbase.org              vect-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
-q2.veupathdb.org               eupa-inc    apicommdevN         acctdbN           webwww            webwww          webwww     apiSite            master
+q2.vectorbase.org              vect068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
+q2.veupathdb.org               eupa068n    apicommdevN         acctdbN           webpatch            webwww          webwww     apiSite            master
 q2.orthomcl.org                rm51069     apicommdevN         acctdbN           webwww            webwww          webwww     orthoSite          master
 
 w1.amoebadb.org                ameb068s    apicommS            acctdbS           webwww            webwww          webwww     apiSite             api-build-68-e


### PR DESCRIPTION
setting genomic qa sites (q2 ) on prod databases with webpatch account so no cache issues.  this is needed to qa the new jbrowse track confgurations in master code comparing prod sites and qa sites usng teh same databases.  if master is fine we will us it next time we need to branch the code.